### PR TITLE
build riscv64 on 3.20, finally

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: docker.io/library/alpine:${{ matrix.target-arch == 'riscv64' && 'edge' || 'latest' }}
+      image: docker.io/library/alpine:latest
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
i see you removed some of the workarounds but missed this one